### PR TITLE
fix(service): fix how translation layer handles previous messages

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -24,9 +24,13 @@ export class TranslationService {
     openAIRequest: OpenAIApiRequest,
     applicationName: string,
   ): DifyApiRequest {
-    const lastMessage = openAIRequest.messages[openAIRequest.messages.length - 1];
+    const formattedMessages = openAIRequest.messages
+      .map((msg) => `${msg.role}: ${msg.content}`)
+      .join('\n');
+    const query = `Chat history:\n${formattedMessages}\n\nPlease respond to the last message.`;
+
     return {
-      query: lastMessage.content,
+      query: query,
       inputs: {},
       user: applicationName,
       response_mode: 'blocking',


### PR DESCRIPTION
Fixes #3 

- instead of keeping only the last message, it now concat previous messages and feed to Dify API as string.
- current implementation is still not optimal, as it does not sollicit Dify's conversation_id.